### PR TITLE
Improve haiku detection using syllables

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,6 @@ of zen and fun into the development process.
 Run the tests with:
 
 ```bash
+pip install -r requirements.txt
 pytest
 ```

--- a/haiku_bot/haiku.py
+++ b/haiku_bot/haiku.py
@@ -2,20 +2,40 @@
 
 from typing import List
 
+import textstat
+
 
 def is_haiku_size(message: str) -> bool:
-    """Return True if the message is exactly 17 characters ignoring spaces."""
-    compact = message.replace(" ", "")
-    return len(compact) == 17
+    """Return ``True`` if the message contains exactly 17 syllables."""
+    return textstat.textstat.syllable_count(message) == 17
 
 
 def to_haiku(message: str) -> List[str]:
-    """Split a 17-character message into 5-7-5 lines.
+    """Split a 17-syllable message into lines of approximately 5-7-5.
 
-    If the message isn't haiku sized, return the original text as a single
-    item list.
+    If the message isn't haiku sized, the original text is returned as a
+    single-element list.
     """
     if not is_haiku_size(message):
         return [message]
-    compact = message.replace(" ", "")
-    return [compact[:5], compact[5:12], compact[12:17]]
+
+    words = message.split()
+    targets = [5, 7, 5]
+    lines: List[str] = []
+    current_words: List[str] = []
+    current_syllables = 0
+    target_index = 0
+
+    for word in words:
+        syllables = textstat.textstat.syllable_count(word)
+        if current_syllables + syllables > targets[target_index]:
+            lines.append(" ".join(current_words))
+            current_words = [word]
+            current_syllables = syllables
+            target_index += 1
+        else:
+            current_words.append(word)
+            current_syllables += syllables
+
+    lines.append(" ".join(current_words))
+    return lines

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+textstat
+black
+flake8
+pytest

--- a/tests/test_haiku.py
+++ b/tests/test_haiku.py
@@ -1,8 +1,11 @@
 from haiku_bot.haiku import is_haiku_size, to_haiku
 
 
+HAIKU = "An old silent pond a frog jumps into the pond splash silence again"
+
+
 def test_is_haiku_size_true():
-    assert is_haiku_size("abcdefg hijklmn opq")
+    assert is_haiku_size(HAIKU)
 
 
 def test_is_haiku_size_false():
@@ -10,6 +13,9 @@ def test_is_haiku_size_false():
 
 
 def test_to_haiku():
-    message = "a" * 17
-    lines = to_haiku(message)
-    assert lines == ["aaaaa", "aaaaaaa", "aaaaa"]
+    lines = to_haiku(HAIKU)
+    assert lines == [
+        "An old silent pond",
+        "a frog jumps into the pond",
+        "splash silence again",
+    ]


### PR DESCRIPTION
## Summary
- count syllables with `textstat` instead of characters
- split lines by syllable counts
- update tests for new behaviour
- document dependency and usage
- add requirements file
- remove unnecessary helper and revert README change

## Testing
- `black haiku_bot tests -q`
- `flake8 haiku_bot tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687bb1fc0ef4832e90a4a9344ad8c3d7