### PR TITLE
Add Microsoft Teams bot integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@ Run the tests with:
 pip install -r requirements.txt
 pytest
 ```
+
+To run the bot with Microsoft Teams:
+
+```bash
+export MicrosoftAppId="<your-app-id>"
+export MicrosoftAppPassword="<your-password>"
+python -m haiku_bot.server
+```

--- a/haiku_bot/__init__.py
+++ b/haiku_bot/__init__.py
@@ -1,6 +1,7 @@
 """MS Teams Haiku Bot package."""
 
-__all__ = ["is_haiku_size", "to_haiku", "handle_message"]
+__all__ = ["is_haiku_size", "to_haiku", "handle_message", "TeamsHaikuBot"]
 
 from .haiku import is_haiku_size, to_haiku
 from .bot import handle_message
+from .teams_bot import TeamsHaikuBot

--- a/haiku_bot/server.py
+++ b/haiku_bot/server.py
@@ -1,0 +1,38 @@
+"""Aiohttp server wiring the bot to Microsoft Teams."""
+
+import os
+from aiohttp import web
+from botbuilder.core import BotFrameworkAdapter, BotFrameworkAdapterSettings
+from botbuilder.schema import Activity
+
+from .teams_bot import TeamsHaikuBot
+
+
+async def messages(request: web.Request) -> web.Response:
+    if "application/json" not in request.headers.get("Content-Type", ""):
+        return web.Response(status=415)
+
+    body = await request.json()
+    activity = Activity().deserialize(body)
+    auth_header = request.headers.get("Authorization", "")
+    response = await ADAPTER.process_activity(
+        activity,
+        auth_header,
+        BOT.on_turn,
+    )
+    if response:
+        return web.json_response(status=response.status)
+    return web.json_response(status=201)
+
+
+APP_ID = os.environ.get("MicrosoftAppId", "")
+APP_PASSWORD = os.environ.get("MicrosoftAppPassword", "")
+SETTINGS = BotFrameworkAdapterSettings(APP_ID, APP_PASSWORD)
+ADAPTER = BotFrameworkAdapter(SETTINGS)
+BOT = TeamsHaikuBot()
+
+APP = web.Application()
+APP.router.add_post("/api/messages", messages)
+
+if __name__ == "__main__":
+    web.run_app(APP, host="0.0.0.0", port=3978)

--- a/haiku_bot/teams_bot.py
+++ b/haiku_bot/teams_bot.py
@@ -1,0 +1,15 @@
+"""Microsoft Teams bot that responds with haikus."""
+
+from botbuilder.core import ActivityHandler, MessageFactory, TurnContext
+
+from .bot import handle_message
+
+
+class TeamsHaikuBot(ActivityHandler):
+    """Bot Framework handler that converts qualifying messages to haiku."""
+
+    async def on_message_activity(self, turn_context: TurnContext) -> None:
+        """Respond to a Teams message."""
+        text = turn_context.activity.text or ""
+        response = handle_message(text)
+        await turn_context.send_activity(MessageFactory.text(response))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ textstat
 black
 flake8
 pytest
+botbuilder-core
+aiohttp
+botbuilder-testing
+pytest-asyncio

--- a/tests/test_teams_bot.py
+++ b/tests/test_teams_bot.py
@@ -1,0 +1,16 @@
+import pytest
+from botbuilder.core.adapters.test_adapter import TestAdapter
+
+from haiku_bot.teams_bot import TeamsHaikuBot
+
+
+@pytest.mark.asyncio
+async def test_teams_haiku_bot():
+    bot = TeamsHaikuBot()
+    adapter = TestAdapter(bot.on_turn)
+
+    await adapter.test("short", "short")
+
+    haiku = "An old silent pond a frog jumps into the pond splash silence again"
+    expected = "An old silent pond\na frog jumps into the pond\nsplash silence again"
+    await adapter.test(haiku, expected)


### PR DESCRIPTION
## Summary
- add Teams bot class and server with aiohttp
- expose `TeamsHaikuBot` in the package
- document running the bot in README
- include Bot Framework packages in requirements
- test Teams integration with `TestAdapter`

## Testing
- `flake8 haiku_bot`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bba907e7c832e8f1d5471b39e6dbe